### PR TITLE
Use `serial_for_url` for serial port, allowing rfc2217

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ de votre fichier `configuration.yaml` avant de redémarrer Home Assistant (ou re
 Une fois redémarré, allez dans: `Paramètres -> Appareils et services -> Ajouter une intégration`. Dans la fenêtre modale qui s'ouvre, cherchez `linky` et sélectionnez l'intégration s'appelant `Linky TIC` dans la liste (une petite icône d'un carton ouvert avec un texte de survol indiquant `Fourni par une extension personnalisée` devrait se trouver sur la droite).
 
 Vous devriez passer sur le formulaire d'installation vous présentant les 3 champs suivants:
-* `Chemin vers le périphérique série` Ici renseignez le path de votre périphérique USB testé précédement. Le champ est rempli par default avec la valeur `/dev/ttyUSB0`: Il ne s'agit pas d'une auto détection mais simplement de la valeure la plus probable dans 99% des installations.
+* `Chemin vers le périphérique série` Ici renseignez le path de votre périphérique USB testé précédement. Le champ est rempli par default avec la valeur `/dev/ttyUSB0`: Il ne s'agit pas d'une auto détection mais simplement de la valeure la plus probable dans 99% des installations. Il est aussi possible d'utiliser une url supporté par [pyserial](https://pyserial.readthedocs.io/en/latest/url_handlers.html), ce qui peut s'avérer utile si le port série est connecté sur un appareil distant.
 * `Mode TIC` Choississez entre `Standard` et `Historique`. Plus de détails sur ces 2 modes en début de ce document.
 * `Triphasé` À cocher si votre compteur est un compteur... triphasé. À noter que cette option n'a d'effet que si vous êtes en mode historique (le mode standard gère le mono et le tri de manière indifférente).
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Cette intégration pour Home Assistant ajoute le support des Linky au travers de
 Par exemple:
 * [Module série USB développé par LiXee](https://lixee.fr/produits/30-tic-din-3770014375070.html) (celui que j'utilise)
 * [Téléinfo 1 compteur USB rail DIN de Cartelectronic](https://www.cartelectronic.fr/teleinfo-compteur-enedis/17-teleinfo-1-compteur-usb-rail-din-3760313520028.html) (validé par un [utilisateur](https://github.com/hekmon/lixeeticdin/issues/2#issuecomment-1364535337))
+* [Circuit à faire soi-même](https://miniprojets.net/index.php/2019/06/28/recuperer-les-donnees-de-son-compteur-linky/), nécessitant peu de composants ([autre article avec un circuit similaire](https://hallard.me/pitinfov12/))
 * et certainement bien d'autres ! (n'hésitez pas à m'ouvrir une issue pour rajouter le votre si vous avez validé que celui-ci fonctionne avec cette intégration afin d'aidez de potentiels futurs utilisateurs qui n'en auraient pas encore choisi un)
 
 [Exemple sous Home Assistant](https://github.com/hekmon/lixeeticdin/raw/v2.0.0-beta2/res/SCR-20221223-ink.png).

--- a/serial_reader.py
+++ b/serial_reader.py
@@ -204,8 +204,8 @@ class LinkyTICReader(threading.Thread):
     def _open_serial(self):
         """Create (and open) the serial connection."""
         try:
-            self._reader = serial.Serial(
-                port=self._port,
+            self._reader = serial.serial_for_url(
+                url=self._port,
                 baudrate=self._baudrate,
                 bytesize=BYTESIZE,
                 parity=PARITY,
@@ -378,8 +378,8 @@ def linky_tic_tester(device: str, std_mode: bool) -> None:
     """Before starting the thread, this method can help validate configuration by opening the serial communication and read a line. It returns None if everything went well or a string describing the error."""
     # Open connection
     try:
-        serial_reader = serial.Serial(
-            port=device,
+        serial_reader = serial.serial_for_url(
+            url=device,
             baudrate=MODE_STANDARD_BAUD_RATE if std_mode else MODE_HISTORIC_BAUD_RATE,
             bytesize=BYTESIZE,
             parity=PARITY,

--- a/translations/en.json
+++ b/translations/en.json
@@ -12,7 +12,7 @@
         "step": {
             "user": {
                 "data": {
-                    "serial_device": "Path to the serial device",
+                    "serial_device": "Path/url to the serial device",
                     "three_phase": "Three-Phase",
                     "tic_mode": "TIC mode"
                 },

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -12,7 +12,7 @@
         "step": {
             "user": {
                 "data": {
-                    "serial_device": "Chemin vers le périphérique série",
+                    "serial_device": "Chemin/adresse vers le périphérique série",
                     "three_phase": "Triphasé",
                     "tic_mode": "Mode TIC"
                 },


### PR DESCRIPTION
Hi,

As my the serial port connected to my Linky is connected to another host than the one running home-assistant, I nedded to use rfc2217 which is supported by pyserial, via the `serial_for_url` method (cf. https://pyserial.readthedocs.io/en/latest/url_handlers.html) 

Moreover, `serial_for_url` can be used as a drop-in replacement for standard `Serial` constructor, that's what is done in this PR.

As an example, the home assistant yaml can now contains:

```
lixeeticdin:
  serial_port: rfc2217://192.168.1.254:10000?ign_set_control
```