### PR TITLE
serial_reader: Fixed RuntimeError: dictionary changed size during ite…

### DIFF
--- a/serial_reader.py
+++ b/serial_reader.py
@@ -184,7 +184,7 @@ class LinkyTICReader(threading.Thread):
         for (
             cached_tag
         ) in (
-            self._values.keys()  # pylint: disable=consider-using-dict-items,consider-iterating-dictionary
+            list(self._values.keys())  # pylint: disable=consider-using-dict-items,consider-iterating-dictionary
         ):
             if cached_tag not in self._tags_seen:
                 _LOGGER.debug(


### PR DESCRIPTION
Upon using the integration, I came across a bug that made all the entities hanged until I restarted my home assistant.

The error was :

```
2023-01-03 13:43:29.725 ERROR (LinkyTIC for rfc2217://192.168.1.254:10000?ign_set_control) [custom_components.linkytic.serial_reader] Failed to parse the following line (1 fields detected) in historic mode: b'I'
2023-01-03 13:43:29.859 ERROR (LinkyTIC for rfc2217://192.168.1.254:10000?ign_set_control) [custom_components.linkytic.serial_reader] Failed to validate the checksum of line 'b'INST 002 Y'': INST -> 002 (None) | s1 496 0b111110000 | truncated 48 0b110000 0 | computed 80 0b1010000 P | expected 89 0b1011001 Y
2023-01-03 13:43:29.864 ERROR (LinkyTIC for rfc2217://192.168.1.254:10000?ign_set_control) [root] Uncaught thread exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/config/custom_components/linkytic/serial_reader.py", line 155, in run
    self._cleanup_cache()
  File "/config/custom_components/linkytic/serial_reader.py", line 184, in _cleanup_cache
    for (
RuntimeError: dictionary changed size during iteration
```

The two first lines were probably caused by a transmission fault, so no issue here. But then it tried to clear cache and it crashes the thread because it tries to remove element from a dictionary that it is currently iterating onto. A simple list copy of the keys fixes this.