### PR TITLE
Handle empty checksum

### DIFF
--- a/serial_reader.py
+++ b/serial_reader.py
@@ -285,6 +285,9 @@ class LinkyTICReader(threading.Thread):
                 )
                 return None
         # validate the checksum
+        if not checksum:
+            _LOGGER.error("Empty checksum on line '%s'", repr(line))
+            return None
         try:
             self._validate_checksum(tag, timestamp, field_value, checksum)
         except InvalidChecksum as invalid_checksum:


### PR DESCRIPTION
Hi,

I got an Exception  because, after a transmission error, a line was correctly parsed but the `checksum` variable was empty and thus raised a `TypeError` in `_validate_checksum` (because of `ord(checksum)`).

This PR fixes it (tested without failure for a week now)